### PR TITLE
insert h5p by slug

### DIFF
--- a/admin/class-h5p-content-admin.php
+++ b/admin/class-h5p-content-admin.php
@@ -601,7 +601,7 @@ class H5PContentAdmin {
 
     // Different fields for insert
     if ($insert) {
-      $fields = array('id', 'title', 'content_type', 'updated_at');
+      $fields = array('id', 'title', 'content_type', 'updated_at', 'slug');
     }
     else {
       $fields = array('id', 'title', 'content_type', 'created_at', 'updated_at', 'user_name', 'user_id');
@@ -642,7 +642,7 @@ class H5PContentAdmin {
       esc_html($result->title),
       esc_html($result->content_type),
       date($datetimeformat, strtotime($result->updated_at) + $offset),
-      '<button class="button h5p-insert" data-id="' . $result->id . '">' . __('Insert', $this->plugin_slug) . '</button>'
+      '<button class="button h5p-insert" data-id="' . $result->id . '" data-slug="' . $result->slug . '">' . __('Insert', $this->plugin_slug) . '</button>'
     );
   }
 

--- a/admin/class-h5p-content-query.php
+++ b/admin/class-h5p-content-query.php
@@ -31,6 +31,7 @@ class H5PContentQuery {
     'id' => array('hc', 'id'),
     'title' => array('hc', 'title', TRUE),
     'content_type' => array('hl', 'title', TRUE),
+    'slug' => array('hc', 'slug', TRUE),
     'created_at' => array('hc', 'created_at'),
     'updated_at' => array('hc', 'updated_at'),
     'user_id' => array('u', 'ID'),

--- a/admin/scripts/h5p-data-views.js
+++ b/admin/scripts/h5p-data-views.js
@@ -37,11 +37,28 @@
           // Data loaded
           $wrapper.find('.h5p-insert').click(function () {
             // Inserting content
-            send_to_editor('[h5p id="' + $(this).data('id') + '"]');
+            if ($('#insert-h5p-as').val()=='slug')
+              send_to_editor('[h5p slug="' + $(this).data('slug') + '"]');
+
+            else
+              send_to_editor('[h5p id="' + $(this).data('id') + '"]');
+
             $wrapper.detach();
             $('#TB_window').removeClass('h5p-insertion');
             tb_remove();
           });
+
+          // Append insert method selection
+          if (!$('#insert-h5p-as').length) {
+            var methodHtml=
+              '<div style="position: absolute; top: 0; right: 0; margin: 0.5em">'+
+              '<select id="insert-h5p-as">'+
+              '<option value="id">Insert using id</option>'+
+              '<option value="slug">Insert using slug</option>'+
+              '</select>'+
+              '</div>';
+            $('#h5p-insert-content').append(methodHtml);
+          }
         });
       }
       else {

--- a/admin/scripts/h5p-data-views.js
+++ b/admin/scripts/h5p-data-views.js
@@ -37,11 +37,12 @@
           // Data loaded
           $wrapper.find('.h5p-insert').click(function () {
             // Inserting content
-            if ($('#insert-h5p-as').val()=='slug')
+            if ($('#insert-h5p-as').val()=='slug') {
               send_to_editor('[h5p slug="' + $(this).data('slug') + '"]');
-
-            else
+            }
+            else {
               send_to_editor('[h5p id="' + $(this).data('id') + '"]');
+            }
 
             $wrapper.detach();
             $('#TB_window').removeClass('h5p-insertion');
@@ -51,7 +52,7 @@
           // Append insert method selection
           if (!$('#insert-h5p-as').length) {
             var methodHtml=
-              '<div style="position: absolute; top: 0; right: 0; margin: 0.5em">'+
+              '<div class="h5p-insert-method-holder">'+
               '<select id="insert-h5p-as">'+
               '<option value="id">Insert using id</option>'+
               '<option value="slug">Insert using slug</option>'+

--- a/admin/styles/admin.css
+++ b/admin/styles/admin.css
@@ -91,6 +91,12 @@
 .h5p-insertion td:nth-child(6) {
   text-align: right;
 }
+.h5p-insert-method-holder {
+  position: absolute;
+  top: 0;
+  right: 0;
+  margin: 0.5em;
+}
 .h5p-disable-file-check {
   margin-top: 0.5em;
 }

--- a/public/class-h5p-plugin.php
+++ b/public/class-h5p-plugin.php
@@ -593,6 +593,25 @@ class H5P_Plugin {
    * @return string
    */
   public function shortcode($atts) {
+    global $wpdb;
+    if (isset($atts['slug'])) {
+      $q=$wpdb->prepare(
+        "SELECT  id ".
+        "FROM    {$wpdb->prefix}h5p_contents ".
+        "WHERE   slug=%s",
+        $atts['slug']
+      );
+      $row=$wpdb->get_row($q,ARRAY_A);
+
+      if ($wpdb->last_error)
+        return sprintf(__('Database error: %s.', $this->plugin_slug), $wpdb->last_error);
+
+      if (!isset($row['id']))
+        return sprintf(__('Cannot find H5P content with slug: %s.', $this->plugin_slug), $atts['slug']);
+
+      $atts['id']=$row['id'];
+    }
+
     $id = isset($atts['id']) ? intval($atts['id']) : NULL;
     $content = $this->get_content($id);
     if (is_string($content)) {

--- a/public/class-h5p-plugin.php
+++ b/public/class-h5p-plugin.php
@@ -603,11 +603,13 @@ class H5P_Plugin {
       );
       $row=$wpdb->get_row($q,ARRAY_A);
 
-      if ($wpdb->last_error)
+      if ($wpdb->last_error) {
         return sprintf(__('Database error: %s.', $this->plugin_slug), $wpdb->last_error);
+      }
 
-      if (!isset($row['id']))
+      if (!isset($row['id'])) {
         return sprintf(__('Cannot find H5P content with slug: %s.', $this->plugin_slug), $atts['slug']);
+      }
 
       $atts['id']=$row['id'];
     }


### PR DESCRIPTION
I added the possibility to reference h5p content by slug as well as by id. The rationale for this is that the slug has a greater chance of staying consistent if the content is moved from one site to another. Specifically, I implemented it this way:

* I added functionality to the h5p shortcode so you can use `[h5p slug="..."]` as well as `[h5p id="..."]`.
* I added a drop down in the "Insert H5P Content" popup with the possibility to select insertion method.

The code in its current implementation might not be up to your coding standards when it comes to how the database is accessed and how the dialog is created. Please take a look and let me know how you want it done and I can change the code.

Cheers!

![insert-by-slug](https://cloud.githubusercontent.com/assets/902911/11819888/56d18090-a373-11e5-8f29-cb5e893e8890.png)