### PR TITLE
Global setting to insert content by id or slug

### DIFF
--- a/admin/class-h5p-content-admin.php
+++ b/admin/class-h5p-content-admin.php
@@ -526,7 +526,20 @@ class H5PContentAdmin {
    */
   public function add_insert_button() {
     $this->insertButton = TRUE;
-    return '<a href="#" id="add-h5p" class="button" title="' . __('Insert H5P Content', $this->plugin_slug) . '">' . __('Add H5P', $this->plugin_slug) . '</a>';
+
+    $insert_method = get_option('h5p_insert_method', 'id');
+
+    $button_content = "";
+
+    $button_content .= 
+      '<script>H5P_INSERT_METHOD="' . $insert_method . '"</script>';
+
+    $button_content .=
+      '<a href="#" id="add-h5p" class="button" title="' . __('Insert H5P Content', $this->plugin_slug) . '">' . 
+      __('Add H5P', $this->plugin_slug) . 
+      '</a>';
+
+    return $button_content;
   }
 
   /**

--- a/admin/class-h5p-plugin-admin.php
+++ b/admin/class-h5p-plugin-admin.php
@@ -403,6 +403,9 @@ class H5P_Plugin_Admin {
 
       $save_content_frequency = filter_input(INPUT_POST, 'save_content_frequency', FILTER_VALIDATE_INT);
       update_option('h5p_save_content_frequency', $save_content_frequency);
+
+      $insert_method = filter_input(INPUT_POST, 'insert_method', FILTER_SANITIZE_SPECIAL_CHARS);
+      update_option('h5p_insert_method', $insert_method);
     }
     else {
       $frame = get_option('h5p_frame', TRUE);
@@ -414,6 +417,7 @@ class H5P_Plugin_Admin {
       $library_updates = get_option('h5p_library_updates', TRUE);
       $save_content_state = get_option('h5p_save_content_state', FALSE);
       $save_content_frequency = get_option('h5p_save_content_frequency', 30);
+      $insert_method = get_option('h5p_insert_method', 'id');
     }
 
     include_once('views/settings.php');

--- a/admin/scripts/h5p-data-views.js
+++ b/admin/scripts/h5p-data-views.js
@@ -37,7 +37,7 @@
           // Data loaded
           $wrapper.find('.h5p-insert').click(function () {
             // Inserting content
-            if ($('#insert-h5p-as').val()=='slug') {
+            if (H5P_INSERT_METHOD == 'slug') {
               send_to_editor('[h5p slug="' + $(this).data('slug') + '"]');
             }
             else {
@@ -48,18 +48,6 @@
             $('#TB_window').removeClass('h5p-insertion');
             tb_remove();
           });
-
-          // Append insert method selection
-          if (!$('#insert-h5p-as').length) {
-            var methodHtml=
-              '<div class="h5p-insert-method-holder">'+
-              '<select id="insert-h5p-as">'+
-              '<option value="id">Insert using id</option>'+
-              '<option value="slug">Insert using slug</option>'+
-              '</select>'+
-              '</div>';
-            $('#h5p-insert-content').append(methodHtml);
-          }
         });
       }
       else {

--- a/admin/views/settings.php
+++ b/admin/views/settings.php
@@ -101,7 +101,7 @@
               <input type="radio" name="insert_method" value="slug"
                 <?php if ($insert_method == "slug"): ?>checked="checked"<?php endif; ?>
               />
-              <?php _e("Reference content by slug", $this->plugin_slug); ?></th>
+              <?php _e("Reference content by <a href='https://en.wikipedia.org/wiki/Semantic_URL#Slug' target='_blank'>slug</a>", $this->plugin_slug); ?></th>
             </p>
           </td>
         </tr>

--- a/admin/views/settings.php
+++ b/admin/views/settings.php
@@ -85,6 +85,26 @@
             </p>
           </td>
         </tr>
+        <tr valign="top">
+          <th scope="row"><?php _e("Add content method", $this->plugin_slug); ?></th>
+          <td>
+            <p>
+              <?php _e('When adding H5P content to posts and pages using the "Add H5P" button:', $this->plugin_slug); ?>
+            </p>
+            <p>
+              <input type="radio" name="insert_method" value="id"
+                <?php if ($insert_method == "id"): ?>checked="checked"<?php endif; ?>
+              />
+              <?php _e("Reference content by id", $this->plugin_slug); ?></th>
+            </p>
+            <p>
+              <input type="radio" name="insert_method" value="slug"
+                <?php if ($insert_method == "slug"): ?>checked="checked"<?php endif; ?>
+              />
+              <?php _e("Reference content by slug", $this->plugin_slug); ?></th>
+            </p>
+          </td>
+        </tr>
       </tbody>
     </table>
     <?php wp_nonce_field('h5p_settings', 'save_these_settings'); ?>

--- a/uninstall.php
+++ b/uninstall.php
@@ -90,6 +90,7 @@ function _h5p_uninstall() {
   delete_option('h5p_update_available');
   delete_option('h5p_current_update');
   delete_option('h5p_update_available_path');
+  delete_option('h5p_insert_method');
 
   // Clean out file dirs.
   $upload_dir = wp_upload_dir();


### PR DESCRIPTION
For reference, see https://github.com/h5p/h5p-wordpress-plugin/pull/27, as this PR builds on that one with a slightly modified behavior.

In an email discussion with @falcon-git, a few things emerged:

* The dropdown in the "Add H5P" popup is kind of cluttering the UI.
* It is unlikely that you would want to change this setting per inserted content. It makes more sense to have it as a site wide policy.

In this PR, the setting is instead global and on the H5P settings page, like so:

![h5p_add_content_setting](https://cloud.githubusercontent.com/assets/902911/12445893/18b1ce2a-bf78-11e5-81db-c7031f64a895.png)

Someone might have opinions about the way the setting is communicated from PHP to JavaScript, it is done by inserting a script tag next to the button, for details see near [this](https://github.com/limikael/h5p-wordpress-plugin/blob/master/admin/class-h5p-content-admin.php#L535) line. 

If some other method is better, let me know and I will change it!