### PR TITLE
fixed fetchExternalData of WP_Error arrays error

### DIFF
--- a/public/class-h5p-wordpress.php
+++ b/public/class-h5p-wordpress.php
@@ -818,11 +818,13 @@ class H5PWordPress implements H5PFrameworkInterface {
    * Implements fetchExternalData
    */
   public function fetchExternalData($url) {
-    $data = wp_remote_get($url);
-    if ($data['response']['code'] === 200) {
-      return $data['body'];
+    $response = wp_remote_get( $url );
+    if(is_array($response) && array_key_exists('body', $response))
+    {
+            $data = json_decode( $response['body'], true );
+            return $data;
     }
-
+    
     return NULL;
   }
 


### PR DESCRIPTION
the issue can be reproduced at wordpress 4.4.1. The plugin failed to be activated.