### PR TITLE
Update new-content.php

### DIFF
--- a/admin/views/new-content.php
+++ b/admin/views/new-content.php
@@ -52,9 +52,9 @@
         </div>
         <div id="major-publishing-actions" class="submitbox">
           <?php if ($this->content !== NULL): ?>
-            <a class="submitdelete deletion" href="<?php print wp_nonce_url(admin_url('admin.php?page=h5p_new&id=' . $this->content['id']), 'deleting_h5p_content', 'delete'); ?>">Delete</a>
+            <a class="submitdelete deletion" href="<?php print wp_nonce_url(admin_url('admin.php?page=h5p_new&id=' . $this->content['id']), 'deleting_h5p_content', 'delete'); ?>"><?php esc_html_e('Delete') ?></a>
           <?php endif; ?>
-          <input type="submit" name="submit" value="<?php esc_html_e($this->content === NULL ? 'Create' : 'Update', $this->plugin_slug) ?>" class="button button-primary button-large"/>
+          <input type="submit" name="submit" value="<?php $this->content === NULL ? esc_html_e('Create', $this->plugin_slug) : esc_html_e('Update')?>"class="button button-primary button-large"/>
         </div>
       </div>
       <?php if (get_option('h5p_frame', TRUE)): ?>


### PR DESCRIPTION
To fix 2 translation problems on the edit actions page.
1.- line 55 missing call to language translation for string "Delete"
2.- line 57 : there is no "Update" string available in the language files, but we can use the WordPress translation for "Update" instead.