### PR TITLE
Change Node Order below New Post, Page, Etc.

### DIFF
--- a/public/class-h5p-plugin.php
+++ b/public/class-h5p-plugin.php
@@ -98,7 +98,7 @@ class H5P_Plugin {
     add_action('init', array('H5P_Plugin', 'check_for_updates'), 1);
 
     // Add menu options to admin bar.
-    add_action('admin_bar_menu', array($this, 'admin_bar'));
+    add_action('admin_bar_menu', array($this, 'admin_bar'), 999);
   }
 
   /**


### PR DESCRIPTION
I love H5P, but in the hierarchy of content creation, the Post on a WP site should probably take priority over the H5P Content. This change moves the H5P Content node lower in the "+ New" Admin Bar group.