### PR TITLE
Provide optional array of head tags to embed.php

### DIFF
--- a/admin/class-h5p-plugin-admin.php
+++ b/admin/class-h5p-plugin-admin.php
@@ -200,6 +200,9 @@ class H5P_Plugin_Admin {
           $scripts = array_merge($scripts, $core->getAssetsUrls($files['scripts']));
           $styles = array_merge($styles, $core->getAssetsUrls($files['styles']));
 
+          $additional_embed_head_tags = array();
+          do_action_ref_array('h5p_additional_embed_head_tags', array(&$additional_embed_head_tags));
+
           include_once(plugin_dir_path(__FILE__) . '../h5p-php-library/embed.php');
 
           // Log embed view


### PR DESCRIPTION
Works in conjuntion with modifications to embed.php in the
h5p-php-library.  Allows other plugins to add code to be inserted into
the head of the embeded iframe generated by embed.php.

See disucssion of this issue here:
https://github.com/h5p/h5p-wordpress-plugin/issues/58#issuecomment-337906304