### PR TITLE
Improve layout of data view on narrow screens

### DIFF
--- a/admin/styles/admin.css
+++ b/admin/styles/admin.css
@@ -237,6 +237,20 @@
 }
 
 @media screen and (max-width: 782px) {
+  #wpwrap {
+    overflow-x: auto;
+  }
+  .h5p-data-view {
+    margin-top: 1em;
+    min-width: 600px; /* width of next media query in hierarchy */
+  }
+  .h5p-data-view thead th {
+    vertical-align: top;
+    word-wrap: break-word;
+  }
+  .h5p-data-view tbody td, .h5p-data-view tfoot td {
+    display: table-cell!important; /* WP media query has priority */
+  }
   .wrap h2 {
     margin-bottom: 0.25em;
   }

--- a/admin/styles/admin.css
+++ b/admin/styles/admin.css
@@ -249,7 +249,7 @@
     word-wrap: break-word;
   }
   .h5p-data-view tbody td, .h5p-data-view tfoot td {
-    display: table-cell!important; /* WP media query has priority */
+    display: table-cell !important; /* WP media query has priority */
   }
   .wrap h2 {
     margin-bottom: 0.25em;


### PR DESCRIPTION
If merged in, this pull request will stop the WordPress media query for screens of a width smaller than 782 pixels from breaking the data view layout.

Resolves https://github.com/h5p/h5p-wordpress-plugin/issues/71 and https://h5ptechnology.atlassian.net/browse/HFP-2086