### PR TITLE
Add overflow-x scrollbar for data views that are too narrow

### DIFF
--- a/admin/styles/admin.css
+++ b/admin/styles/admin.css
@@ -237,6 +237,10 @@
 }
 
 @media screen and (max-width: 782px) {
+  #wpbody-content .wrap {
+    overflow-x: auto;
+  }
+
   #wpwrap {
     overflow-x: auto;
   }


### PR DESCRIPTION
I assume that some class in WordPress was renamed at some point, and the overflow-x property wasn't set anymore, so data views wouldn't get a scrollbar on screens that are too narrow. (Re)-added here. Left the other property declaration for `#wprwap` below because I a not sure if it serves a different purpose. 