### PR TITLE
Copy full metadata into cloned activity

### DIFF
--- a/public/class-h5p-plugin.php
+++ b/public/class-h5p-plugin.php
@@ -1520,13 +1520,18 @@ class H5P_Plugin {
       throw new Exception('Failed validating .h5p file');
     }
 
+    // Prepare metadata
+    $metadata = empty($validator->h5pC->mainJsonData) ? array() : $validator->h5pC->mainJsonData;
+
+    // Use a default string if title from h5p.json is not available
+    if (empty($metadata['title'])) {
+      $metadata['title'] = 'Uploaded Content';
+    }
+
     // Create content
     $content = array(
       'disable' => H5PCore::DISABLE_NONE,
-      'metadata' => array(
-        // Fetch title from h5p.json or use a default string if not available
-        'title' => empty($validator->h5pC->mainJsonData['title']) ? 'Uploaded Content' : $validator->h5pC->mainJsonData['title']
-      )
+      'metadata' => $metadata,
     );
 
     // Save content


### PR DESCRIPTION
This PR addresses issue described on [conversation](https://github.com/h5p/h5p-wordpress-plugin/issues/63#issuecomment-579680578), related to missing metadata on cloned H5P activities. 