### PR TITLE
Save content state in browser local storage (settings)

### DIFF
--- a/admin/class-h5p-plugin-admin.php
+++ b/admin/class-h5p-plugin-admin.php
@@ -454,6 +454,9 @@ class H5P_Plugin_Admin {
       $save_content_frequency = filter_input(INPUT_POST, 'save_content_frequency', FILTER_VALIDATE_INT);
       update_option('h5p_save_content_frequency', $save_content_frequency);
 
+      $save_content_storages = filter_input(INPUT_POST, 'save_content_storages', FILTER_VALIDATE_INT);
+      update_option('h5p_save_content_storages', $save_content_storages);
+
       $show_toggle_view_others_h5p_contents = filter_input(INPUT_POST, 'show_toggle_view_others_h5p_contents', FILTER_VALIDATE_INT);
       update_option('h5p_show_toggle_view_others_h5p_contents', $show_toggle_view_others_h5p_contents);
 
@@ -496,6 +499,7 @@ class H5P_Plugin_Admin {
       $track_user = get_option('h5p_track_user', TRUE);
       $save_content_state = get_option('h5p_save_content_state', FALSE);
       $save_content_frequency = get_option('h5p_save_content_frequency', 30);
+      $save_content_storages = get_option('h5p_save_content_storages', 1);
       $show_toggle_view_others_h5p_contents = get_option('h5p_show_toggle_view_others_h5p_contents', 0);
       $insert_method = get_option('h5p_insert_method', 'id');
       $enable_lrs_content_types = get_option('h5p_enable_lrs_content_types', FALSE);

--- a/admin/views/settings.php
+++ b/admin/views/settings.php
@@ -113,13 +113,28 @@
           <th scope="row"><?php _e("Save Content State", $this->plugin_slug); ?></th>
           <td>
             <label>
-              <input name="save_content_state" type="checkbox" value="true"<?php if ($save_content_state): ?> checked="checked"<?php endif; ?>/>
-              <?php _e("Allow logged-in users to resume tasks", $this->plugin_slug); ?>
+              <input class="h5p-visibility-toggler" data-h5p-visibility-subject-selector=".h5p-save-content-options" name="save_content_state" type="checkbox" value="true"<?php if ($save_content_state): ?> checked="checked"<?php endif; ?>/>
+              <?php _e("Allow users to resume tasks", $this->plugin_slug); ?>
             </label>
-            <p class="h5p-auto-save-freq">
-              <label for="h5p-freq"><?php _e("Auto-save frequency (in seconds)", $this->plugin_slug); ?></label>
-              <input id="h5p-freq" name="save_content_frequency" type="text" value="<?php print $save_content_frequency ?>"/>
-            </p>
+          </td>
+        </tr>
+        <tr valign="top" class="h5p-save-content-options">
+          <th scope="row"><?php _e("Auto-save frequency (in seconds)", $this->plugin_slug); ?></th>
+          <td>
+            <input id="h5p-freq" name="save_content_frequency" type="text" value="<?php print $save_content_frequency ?>"/>
+          </td>
+        </tr>
+        <tr valign="top" class="h5p-save-content-options">
+          <th scope="row"><?php _e("Users who may resume tasks", $this->plugin_slug); ?></th>
+          <td>
+            <select id="h5p_save_content_storages" name="save_content_storages">
+              <option value="<?php echo H5PSaveContentStorages::DATABASE; ?>" <?php if ($save_content_storages == H5PSaveContentStorages::DATABASE): ?>selected="selected"<?php endif; ?>>
+                <?php _e("Only users who are logged-in", $this->plugin_slug); ?>
+              </option>
+              <option value="<?php echo H5PSaveContentStorages::DATABASE_LOCALSTORAGE; ?>" <?php if ($save_content_storages == H5PSaveContentStorages::DATABASE_LOCALSTORAGE): ?>selected="selected"<?php endif; ?>>
+                <?php _e("All users", $this->plugin_slug); ?>
+              </option>
+            </select>
           </td>
         </tr>
         </tr>

--- a/public/class-h5p-plugin.php
+++ b/public/class-h5p-plugin.php
@@ -388,6 +388,7 @@ class H5P_Plugin {
     add_option('h5p_track_user', TRUE);
     add_option('h5p_save_content_state', FALSE);
     add_option('h5p_save_content_frequency', 30);
+    add_option('h5p_save_content_storages', 1);
     add_option('h5p_site_key', get_option('h5p_h5p_site_uuid', FALSE));
     add_option('h5p_show_toggle_view_others_h5p_contents', 0);
     add_option('h5p_content_type_cache_updated_at', 0);
@@ -799,6 +800,27 @@ class H5P_Plugin {
   }
 
   /**
+   * Get the storages for save content state.
+   *
+   * @since 1.15.1
+   * @return string
+   */
+  public function get_h5p_save_content_storages() {
+    $save_content_storages = array();
+
+    $option = get_option('h5p_save_content_storages', FALSE);
+
+    if (($option & H5PSaveContentStorages::DATABASE) === H5PSaveContentStorages::DATABASE) {
+      $save_content_storages['database'] = TRUE;
+    }
+    if (($option & H5PSaveContentStorages::LOCALSTORAGE) === H5PSaveContentStorages::LOCALSTORAGE) {
+      $save_content_storages['localStorage'] = TRUE;
+    }
+
+    return $save_content_storages;
+  }
+
+  /**
    * Get H5P language code from WordPress.
    *
    * @since 1.0.0
@@ -1174,6 +1196,7 @@ class H5P_Plugin {
         'contentUserData' => admin_url('admin-ajax.php?token=' . wp_create_nonce('h5p_contentuserdata') . '&action=h5p_contents_user_data&content_id=:contentId&data_type=:dataType&sub_content_id=:subContentId')
       ),
       'saveFreq' => get_option('h5p_save_content_state', FALSE) ? get_option('h5p_save_content_frequency', 30) : FALSE,
+      'saveContentStorages' => $this->get_h5p_save_content_storages(),
       'siteUrl' => get_site_url(),
       'l10n' => array(
         'H5P' => $core->getLocalization(),
@@ -1604,6 +1627,7 @@ class H5P_Plugin {
     delete_option('h5p_ext_communication');
     delete_option('h5p_save_content_state');
     delete_option('h5p_save_content_frequency');
+    delete_option('h5p_save_content_storages');
     delete_option('h5p_show_toggle_view_others_h5p_contents');
     delete_option('h5p_update_available');
     delete_option('h5p_current_update');

--- a/public/class-h5p-plugin.php
+++ b/public/class-h5p-plugin.php
@@ -808,6 +808,10 @@ class H5P_Plugin {
   public function get_h5p_save_content_storages() {
     $save_content_storages = array();
 
+    if (get_option('h5p_save_content_state', FALSE) != TRUE) {
+      return $save_content_storages;
+    }
+
     $option = get_option('h5p_save_content_storages', FALSE);
 
     if (($option & H5PSaveContentStorages::DATABASE) === H5PSaveContentStorages::DATABASE) {

--- a/public/class-h5p-plugin.php
+++ b/public/class-h5p-plugin.php
@@ -818,7 +818,7 @@ class H5P_Plugin {
       $save_content_storages['database'] = TRUE;
     }
     if (($option & H5PSaveContentStorages::LOCALSTORAGE) === H5PSaveContentStorages::LOCALSTORAGE) {
-      $save_content_storages['localStorage'] = TRUE;
+      $save_content_storages['localStorage'] = 'WP-bid-' . get_current_blog_id() . '-';
     }
 
     return $save_content_storages;


### PR DESCRIPTION
Pull request https://github.com/h5p/h5p-php-library/pull/81 will allow H5P to store the current content state in the browser's local storage. It needs to be turned on though.

When merged in, admins can set the current state to also be stored in the browser local storage, so student can resume their exercises even if they are not logged in.

Requires https://github.com/h5p/h5p-php-library/pull/81 to take effect.

## Implementation details
- Add select field to WordPress options labeled "Users who may resume tasks" with options
  - "Only users who are logged-in" (= current behavior when "save content state" is activated; default)
  - "All users" (= storing in database and local storage)
- New option will only be visible when "save content state" is activated
- Bonus: Frequency for saving option will also only be visible when "save content state" is activated