### PR TITLE
New print_h5p_content filter

### DIFF
--- a/public/class-h5p-plugin.php
+++ b/public/class-h5p-plugin.php
@@ -1048,7 +1048,7 @@ class H5P_Plugin {
     }
 
     if ($embed === 'div') {
-      return '<div class="h5p-content" data-content-id="' . $content['id'] . '"></div>';
+        $h5p_content =  '<div class="h5p-content" data-content-id="' . $content['id'] . '"></div>';
     }
     else {
       $title = isset($content['metadata']['a11yTitle'])
@@ -1057,8 +1057,10 @@ class H5P_Plugin {
           ? $content['metadata']['title']
           : ''
         );
-      return '<div class="h5p-iframe-wrapper"><iframe id="h5p-iframe-' . $content['id'] . '" class="h5p-iframe" data-content-id="' . $content['id'] . '" style="height:1px" src="about:blank" frameBorder="0" scrolling="no" title="' . $title . '"></iframe></div>';
+        $h5p_content = '<div class="h5p-iframe-wrapper"><iframe id="h5p-iframe-' . $content['id'] . '" class="h5p-iframe" data-content-id="' . $content['id'] . '" style="height:1px" src="about:blank" frameBorder="0" scrolling="no" title="' . $title . '"></iframe></div>';
     }
+
+    return apply_filters('print_h5p_content', $h5p_content);
   }
 
   /**

--- a/public/class-h5p-plugin.php
+++ b/public/class-h5p-plugin.php
@@ -1060,7 +1060,7 @@ class H5P_Plugin {
         $h5p_content = '<div class="h5p-iframe-wrapper"><iframe id="h5p-iframe-' . $content['id'] . '" class="h5p-iframe" data-content-id="' . $content['id'] . '" style="height:1px" src="about:blank" frameBorder="0" scrolling="no" title="' . $title . '"></iframe></div>';
     }
 
-    return apply_filters('print_h5p_content', $h5p_content);
+    return apply_filters('print_h5p_content', $h5p_content, $content);
   }
 
   /**

--- a/public/class-h5p-plugin.php
+++ b/public/class-h5p-plugin.php
@@ -1048,7 +1048,7 @@ class H5P_Plugin {
     }
 
     if ($embed === 'div') {
-        $h5p_content =  '<div class="h5p-content" data-content-id="' . $content['id'] . '"></div>';
+        $h5p_content_wrapper =  '<div class="h5p-content" data-content-id="' . $content['id'] . '"></div>';
     }
     else {
       $title = isset($content['metadata']['a11yTitle'])
@@ -1057,10 +1057,10 @@ class H5P_Plugin {
           ? $content['metadata']['title']
           : ''
         );
-        $h5p_content = '<div class="h5p-iframe-wrapper"><iframe id="h5p-iframe-' . $content['id'] . '" class="h5p-iframe" data-content-id="' . $content['id'] . '" style="height:1px" src="about:blank" frameBorder="0" scrolling="no" title="' . $title . '"></iframe></div>';
+        $h5p_content_wrapper = '<div class="h5p-iframe-wrapper"><iframe id="h5p-iframe-' . $content['id'] . '" class="h5p-iframe" data-content-id="' . $content['id'] . '" style="height:1px" src="about:blank" frameBorder="0" scrolling="no" title="' . $title . '"></iframe></div>';
     }
 
-    return apply_filters('print_h5p_content', $h5p_content, $content);
+    return apply_filters('print_h5p_content', $h5p_content_wrapper, $content);
   }
 
   /**


### PR DESCRIPTION
I added a custom filter `print_h5p_content ` to be able to hook the h5p HTML content wrapper creation, this could be useful to modify the wrapper of each h5p activity.

### Problem

There is no a way to modify the HTML output for each h5p activity

### Solution

We need to create a specific anchor link to each h5p activity, currently the `h5p-iframe-wrapper` uses `h5p-iframe-' . $content['id']` to identify each activity however we need a unique identifier so it could be solved adding an extra wrapper.

We think this could be useful for other developers to modify the HTML output in a clean way.

### Example

```php
add_filter('print_h5p_content', function($content) {
    return '<div class="customWrapper">'.$content.'</div>';
});
```

We think this could be a good addition to the plugin :) Thank you