### PR TITLE
HFP-3065 Allow to delete library if circular dependency

### DIFF
--- a/admin/class-h5p-library-admin.php
+++ b/admin/class-h5p-library-admin.php
@@ -201,6 +201,7 @@ class H5PLibraryAdmin {
           'numContent' => $contents_count === 0 ? '' : $contents_count,
           'numContentDependencies' => $usage['content'] < 1 ? '' : $usage['content'],
           'numLibraryDependencies' => $usage['libraries'] === 0 ? '' : $usage['libraries'],
+          'hasCircularEditorDepencendy' => $usage['hasCircularEditorDepencendy'],
           'upgradeUrl' => $upgradeUrl,
           'detailsUrl' => admin_url('admin.php?page=h5p_libraries&task=show&id=' . $library->id),
           'deleteUrl' => admin_url('admin.php?page=h5p_libraries&task=delete&id=' . $library->id)
@@ -304,7 +305,8 @@ class H5PLibraryAdmin {
 
       // Check if this library can be deleted
       $usage = $interface->getLibraryUsage($library->id, $interface->getNumNotFiltered() ? TRUE : FALSE);
-      if ($usage['content'] !== 0 || $usage['libraries'] !== 0) {
+      $delete_circular_editor_dependency = $usage['hasCircularEditorDepencendy'] && $usage['content'] === 0 && $usage['libraries'] === 1;
+      if (!$delete_circular_editor_dependency && ($usage['content'] !== 0 || $usage['libraries'] !== 0)) {
         H5P_Plugin_Admin::set_error(__('This Library is used by content or other libraries and can therefore not be deleted.', $this->plugin_slug));
         return; // Nope
       }


### PR DESCRIPTION
A long time ago in a galaxy far far away, the `H5PLibraryList` class was created to allow H5P library management - including deletion of libraries. Libraries cannot be deleted, of course, if some content or library still depends on it.

Unfortunately, it is possible that a content library is used for the view and the editor alike, e.g. Course Presentation. _H5P.CoursePresentation_ has an "editor" dependency to _H5PEditor.CoursePresentation_, and _H5PEditor.CoursePresentation_ has a "preloaded" dependency to _H5P.CoursePresentation_. This direct circular dependency prevents both libraries from being deleted (without manually modifying the relevant entries in the `h5p_libraries_libraries` database table.

When merged in, this pull request will check for a direct circular dependency (no transitive circles of more than two libraries) when calling `getLibraryUsage()` and set a `hasCircularEditorDepencendy` flag in the return value if appropriate. That flag will be used to check whether a library can be deleted (if the respective editor library is the only library that requires the library at stake) or not.

In order to allow deletion using the GUI of the `H5PLibraryList` class, the pull request for the H5P core at https://github.com/h5p/h5p-php-library/pull/101 will have to me merged in as well.

This pull request could easily be ported to other integrations if it is accepted.