### PR TITLE
Use system temp space instead of temp dir in plugin folder

### DIFF
--- a/admin/class-h5p-plugin-admin.php
+++ b/admin/class-h5p-plugin-admin.php
@@ -465,6 +465,9 @@ class H5P_Plugin_Admin {
       $enable_lrs_content_types = filter_input(INPUT_POST, 'enable_lrs_content_types', FILTER_VALIDATE_BOOLEAN);
       update_option('h5p_enable_lrs_content_types', $enable_lrs_content_types);
 
+      $use_system_temp_dir = filter_input(INPUT_POST, 'use_system_temp_dir', FILTER_VALIDATE_BOOLEAN);
+      update_option('h5p_use_system_temp_dir', $use_system_temp_dir);
+
       // TODO: Make it possible to change site key
 //      $site_key = filter_input(INPUT_POST, 'site_key', FILTER_SANITIZE_SPECIAL_CHARS);
 //      if (preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i', $site_key)) {
@@ -497,6 +500,7 @@ class H5P_Plugin_Admin {
       $about = get_option('h5p_icon', TRUE);
       $track_user = get_option('h5p_track_user', TRUE);
       $save_content_state = get_option('h5p_save_content_state', FALSE);
+      $use_system_temp_dir = get_option('h5p_use_system_temp_dir', FALSE);
       $save_content_frequency = get_option('h5p_save_content_frequency', 30);
       $show_toggle_view_others_h5p_contents = get_option('h5p_show_toggle_view_others_h5p_contents', 0);
       $insert_method = get_option('h5p_insert_method', 'id');

--- a/admin/views/settings.php
+++ b/admin/views/settings.php
@@ -189,6 +189,16 @@
             </p>
           </td>
         </tr>
+        <tr valign="top">
+          <th scope="row"><?php _e("Temporary Working Directory", $this->plugin_slug); ?></th>
+          <td>
+            <label>
+              <input name="use_system_temp_dir" type="checkbox" value="true"<?php if ($use_system_temp_dir): ?> checked="checked"<?php endif; ?>/>
+              <?php _e("Use the system defined temporary space instead of in the plugin directory", $this->plugin_slug); ?>
+            </label>
+          </td>
+        </tr>
+        </tr>
 <!--        <tr valign="top">-->
 <!--          <th scope="row">--><?php //_e("Site Key", $this->plugin_slug); ?><!--</th>-->
 <!--          <td>-->

--- a/public/class-h5p-plugin.php
+++ b/public/class-h5p-plugin.php
@@ -388,6 +388,7 @@ class H5P_Plugin {
     add_option('h5p_icon', TRUE);
     add_option('h5p_track_user', TRUE);
     add_option('h5p_save_content_state', FALSE);
+    add_option('h5p_use_system_temp_dir', FALSE);
     add_option('h5p_save_content_frequency', 30);
     add_option('h5p_site_key', get_option('h5p_h5p_site_uuid', FALSE));
     add_option('h5p_show_toggle_view_others_h5p_contents', 0);

--- a/public/class-h5p-wordpress.php
+++ b/public/class-h5p-wordpress.php
@@ -93,7 +93,7 @@ class H5PWordPress implements H5PFrameworkInterface {
 
     if (is_null($dir)) {
       if (get_option('h5p_use_system_temp_dir', FALSE)) {
-        $path = sys_get_temp_dir();
+        $dir = sys_get_temp_dir() . "/" . uniqid('h5p-');
       } else {
         $plugin = H5P_Plugin::get_instance();
         $core = $plugin->get_h5p_instance('core');
@@ -112,14 +112,13 @@ class H5PWordPress implements H5PFrameworkInterface {
 
     if (is_null($path)) {
       if (get_option('h5p_use_system_temp_dir', FALSE)) {
-        $path = sys_get_temp_dir() . '.h5p';
+        $path = sys_get_temp_dir() . '/' . uniqid('h5p-')  . '.h5p';
       } else {
         $plugin = H5P_Plugin::get_instance();
         $core = $plugin->get_h5p_instance('core');
         $path = $core->fs->getTmpPath() . '.h5p';
       }
     }
-    
     return $path;
   }
 

--- a/public/class-h5p-wordpress.php
+++ b/public/class-h5p-wordpress.php
@@ -92,9 +92,13 @@ class H5PWordPress implements H5PFrameworkInterface {
     static $dir;
 
     if (is_null($dir)) {
-      $plugin = H5P_Plugin::get_instance();
-      $core = $plugin->get_h5p_instance('core');
-      $dir = $core->fs->getTmpPath();
+      if (get_option('h5p_use_system_temp_dir', FALSE)) {
+        $path = sys_get_temp_dir();
+      } else {
+        $plugin = H5P_Plugin::get_instance();
+        $core = $plugin->get_h5p_instance('core');
+        $dir = $core->fs->getTmpPath();
+      }
     }
 
     return $dir;
@@ -107,11 +111,15 @@ class H5PWordPress implements H5PFrameworkInterface {
     static $path;
 
     if (is_null($path)) {
-      $plugin = H5P_Plugin::get_instance();
-      $core = $plugin->get_h5p_instance('core');
-      $path = $core->fs->getTmpPath() . '.h5p';
+      if (get_option('h5p_use_system_temp_dir', FALSE)) {
+        $path = sys_get_temp_dir() . '.h5p';
+      } else {
+        $plugin = H5P_Plugin::get_instance();
+        $core = $plugin->get_h5p_instance('core');
+        $path = $core->fs->getTmpPath() . '.h5p';
+      }
     }
-
+    
     return $path;
   }
 


### PR DESCRIPTION
Hi - 

We use AWS EFS as a backend for wordpress content, and its incredibly slow with regards to lots of small files.  The performance of the upload and changes is substantially better if we change the temp directory of the h5p plugin to use the system temp dir vs EFS.  This patch does just that.  Gives the user the ability to use system temp space.  Please let me know of any thoughts and comments.

Regards,

Al