### PR TITLE
Fix export file not being deleted with content

### DIFF
--- a/admin/class-h5p-content-admin.php
+++ b/admin/class-h5p-content-admin.php
@@ -368,6 +368,7 @@ class H5PContentAdmin {
               $this->content['library']['name'],
               $this->content['library']['majorVersion'] . '.' . $this->content['library']['minorVersion']);
 
+          $this->content = NULL;
           wp_safe_redirect(admin_url('admin.php?page=h5p'));
           return;
         }


### PR DESCRIPTION
Currently, when content is deleted, the export file is deleted with it but re-created instantly when showing the content page from the content parameters that are still set. That may leave the storage cluttered with orphaned files that are not needed anymore.

When merged in, when deleting content the content parameters will be set to NULL and the export file will not be re-created.