### PR TITLE
Fix SQL for extra fields in results

### DIFF
--- a/admin/class-h5p-plugin-admin.php
+++ b/admin/class-h5p-plugin-admin.php
@@ -894,7 +894,7 @@ class H5P_Plugin_Admin {
       $joins .= " LEFT JOIN {$wpdb->prefix}h5p_contents hc ON hr.content_id = hc.id";
     }
     if ($user_id === NULL) {
-      $extra_fields .= " hr.user_id";
+      $extra_fields .= " hr.user_id,";
       $append_user_name = true;
     }
 


### PR DESCRIPTION
Currently, the SQL generated for the results may be invalid. The SQL string is built with optional "extra fields" that will be followed by the regular fields, but the "extra fields" may not terminate with a comma when the `user_id` is added as a field.

Fixed by simply terminating the string with a comma.