### PR TITLE
Fixing a bug that results to a unknown column error during username search in user activity results

### DIFF
--- a/admin/class-h5p-plugin-admin.php
+++ b/admin/class-h5p-plugin-admin.php
@@ -896,6 +896,7 @@ class H5P_Plugin_Admin {
     if ($user_id === NULL) {
       $extra_fields .= " hr.user_id,";
       $append_user_name = true;
+      $joins .= " LEFT JOIN {$wpdb->prefix}users u ON hr.user_id = u.ID";
     }
 
     // Add filters


### PR DESCRIPTION
Fixing a bug that results to a `unknown column error` during username search in user activity results for a content in plugin version `1.15.6`.  

To give more context: 
The line `$append_user_name = true;` is setting a boolean value to determine whether to append the user name to the query.    However, it is not a replacement for the line `$joins .= " LEFT JOIN {$wpdb->prefix}users u ON hr.user_id = u.ID";` that was present before (ie. v`1.15.4`). The line with the LEFT JOIN is actually the join clause of the query that is appended to the main query, and it joins the results table with the users table in order to fetch the user names. The boolean value `$append_user_name seems` to control whether the join clause should be appended to the main query or not.

The error is :
```
[02-Feb-2023 23:45:28 UTC] WordPress database error Unknown column 'u.user_login' in 'where clause' for query SELECT hr.id,
               hr.user_id,
              hr.score,
              hr.max_score,
              hr.opened,
              hr.finished,
              hr.time
        FROM wp_h5p_results hr
        
         WHERE hr.content_id = 36 AND u.user_login LIKE '%iraklis%'
        ORDER BY hr.finished DESC
        LIMIT 0, 20 made by do_action('wp_ajax_h5p_content_results'), WP_Hook->do_action, WP_Hook->apply_filters, H5PContentAdmin->ajax_content_results, H5P_Plugin_Admin->print_results, H5P_Plugin_Admin->get_results
```