### PR TITLE
Fix potential memory issue

### DIFF
--- a/admin/class-h5p-content-admin.php
+++ b/admin/class-h5p-content-admin.php
@@ -925,7 +925,7 @@ class H5PContentAdmin {
       ),
       array(
         'id' => $result->user_id,
-        'title' => esc_html($result->user_name)
+        'title' => empty( $result->user_name ) ? '' : esc_html($result->user_name)
       ),
       $this->format_tags($result->tags),
       $this->format_time($result->updated_at),

--- a/admin/class-h5p-content-query.php
+++ b/admin/class-h5p-content-query.php
@@ -272,14 +272,24 @@ class H5PContentQuery {
       $user_ids[] = $result->user_id;
     }
 
+    // Fail early, as prompting get_users with empty array will fetch all users
+    if ( empty( $user_ids ) ) {
+      return $results;
+    }
+
+    /*
+     * Only used to determine whether there is any WP user for any $user_ids,
+     * so only requesting ID to prevent memory issues
+     */
     $wp_users = get_users(
       array(
         'include' => array_unique( $user_ids ),
+        'fields' => array('ID'),
       )
     );
 
     // If no users are found, there's nothing to do.
-	if ( ! $wp_users ) {
+  	if ( ! $wp_users ) {
       return $results;
     }
 
@@ -293,8 +303,8 @@ class H5PContentQuery {
 
       if ( in_array( 'user_name', $this->fields_raw, true ) ) {
         $result->user_name = $userdata->display_name;
-	  }
-	}
+      }
+    }
 
     return $results;
   }


### PR DESCRIPTION
When merged in, will
- prevent fetching data from all WordPress users if `get_users` is passed an empty array which could result in memory running short and
- limit the amount of data fetched otherwise (as actually none is needed anyway), also reducing memory consumption
- ensure that `esc_html` always has something to work on if for whatever reason no user name can be associated with an entry.

Fixes https://github.com/h5p/h5p-wordpress-plugin/issues/151