### PR TITLE
Make h5p_content_type_cache_updated_at a network setting

### DIFF
--- a/admin/class-h5p-library-admin.php
+++ b/admin/class-h5p-library-admin.php
@@ -239,7 +239,7 @@ class H5PLibraryAdmin {
     H5P_Plugin_Admin::add_script('library-list', 'h5p-php-library/js/h5p-library-list.js');
 
     // Load content type cache time
-    $last_update = get_option('h5p_content_type_cache_updated_at', '');
+    $last_update = get_site_option('h5p_content_type_cache_updated_at', '');
     $hubOn = get_option('h5p_hub_is_enabled', TRUE);
 
     include_once('views/libraries.php');

--- a/public/class-h5p-plugin.php
+++ b/public/class-h5p-plugin.php
@@ -391,7 +391,7 @@ class H5P_Plugin {
     add_option('h5p_save_content_frequency', 30);
     add_option('h5p_site_key', get_option('h5p_h5p_site_uuid', FALSE));
     add_option('h5p_show_toggle_view_others_h5p_contents', 0);
-    add_option('h5p_content_type_cache_updated_at', 0);
+    add_site_option('h5p_content_type_cache_updated_at', 0);
     add_option('h5p_check_h5p_requirements', FALSE);
     add_option('h5p_hub_is_enabled', FALSE);
     add_option('h5p_send_usage_statistics', FALSE);
@@ -1631,7 +1631,7 @@ class H5P_Plugin {
     delete_option('h5p_site_type');
     delete_option('h5p_enable_lrs_content_types');
     delete_option('h5p_site_key');
-    delete_option('h5p_content_type_cache_updated_at');
+    delete_site_option('h5p_content_type_cache_updated_at');
     delete_option('h5p_check_h5p_requirements');
     delete_option('h5p_hub_is_enabled');
     delete_option('h5p_send_usage_statistics');

--- a/public/class-h5p-wordpress.php
+++ b/public/class-h5p-wordpress.php
@@ -11,6 +11,14 @@ class H5PWordPress implements H5PFrameworkInterface {
   private $messages = array('error' => array(), 'info' => array());
 
   /**
+   * Keys that should be stored as a network setting
+   *
+   * @since 1.15.7
+   * @var array
+   */
+  private $networkSettings = array( 'content_type_cache_updated_at' );
+
+  /**
    * Implements setErrorMessage
    */
   public function setErrorMessage($message, $code = NULL) {
@@ -766,7 +774,7 @@ class H5PWordPress implements H5PFrameworkInterface {
    * Implements getOption().
    */
   public function getOption($name, $default = FALSE) {
-    if($name === 'content_type_cache_updated_at') {
+    if(in_array($name, $this->networkSettings)) {
       return get_site_option('h5p_' . $name, $default);
     }
     if ($name === 'site_uuid') {
@@ -784,19 +792,23 @@ class H5PWordPress implements H5PFrameworkInterface {
       $name = 'h5p_site_uuid'; // Make up for old core bug
     }
 
-    //Build function name that will be called
-    $function_suffix = '_option';
-    if($name === 'content_type_cache_updated_at') {
-      $function_suffix = '_site_option';
-    }
-
     $var = $this->getOption($name);
-    $name = 'h5p_' . $name; // Always prefix to avoid conflicts
-    if ($var === FALSE) {
-      call_user_func('add' . $function_suffix, $name, $value);
-    }
-    else {
-      call_user_func('update' . $function_suffix, $name, $value);
+    if(in_array($name, $this->networkSettings)) {
+      $name = 'h5p_' . $name; // Always prefix to avoid conflicts
+      if ($var === FALSE) {
+        add_site_option($name, $value);
+      }
+      else {
+        update_site_option($name, $value);
+      }
+    } else {
+      $name = 'h5p_' . $name; // Always prefix to avoid conflicts
+      if ($var === FALSE) {
+        add_option($name, $value);
+      }
+      else {
+        update_option($name, $value);
+      }
     }
   }
 

--- a/public/class-h5p-wordpress.php
+++ b/public/class-h5p-wordpress.php
@@ -766,6 +766,9 @@ class H5PWordPress implements H5PFrameworkInterface {
    * Implements getOption().
    */
   public function getOption($name, $default = FALSE) {
+    if($name === 'content_type_cache_updated_at') {
+      return get_site_option('h5p_' . $name, $default);
+    }
     if ($name === 'site_uuid') {
       $name = 'h5p_site_uuid'; // Make up for old core bug
     }
@@ -780,13 +783,20 @@ class H5PWordPress implements H5PFrameworkInterface {
     if ($name === 'site_uuid') {
       $name = 'h5p_site_uuid'; // Make up for old core bug
     }
+
+    //Build function name that will be called
+    $function_suffix = '_option';
+    if($name === 'content_type_cache_updated_at') {
+      $function_suffix = '_site_option';
+    }
+
     $var = $this->getOption($name);
     $name = 'h5p_' . $name; // Always prefix to avoid conflicts
     if ($var === FALSE) {
-      add_option($name, $value);
+      call_user_func('add' . $function_suffix, $name, $value);
     }
     else {
-      update_option($name, $value);
+      call_user_func('update' . $function_suffix, $name, $value);
     }
   }
 


### PR DESCRIPTION
This fixes #164.

I'm using the *_site_option methods where relevant and changed the setOption/getOption to be able to give a list of settings that will be set/retrieved using the *_site_option methods. 

From what I can see, there's no way to get global settings in the `H5PFrameworkInterface` defined in the `h5p-php-library`.

I don't know if I should create specific function in `H5PFrameworkInterface` and then implement those in `H5PWordpress` in order to be able to load options that will be global to the plugin. 