### PR TITLE
Don't join against users table when fetching data for 'results' panel.

### DIFF
--- a/admin/class-h5p-plugin-admin.php
+++ b/admin/class-h5p-plugin-admin.php
@@ -896,7 +896,6 @@ class H5P_Plugin_Admin {
     if ($user_id === NULL) {
       $extra_fields .= " hr.user_id,";
       $append_user_name = true;
-      $joins .= " LEFT JOIN {$wpdb->base_prefix}users u ON hr.user_id = u.ID";
     }
 
     // Add filters


### PR DESCRIPTION
Previously: #133 

In that pull request I missed this instance (or perhaps it was added afterward).

In this specific case, joining against the users table doesn't provide much benefit, given that no `u.` fields are selected by the query. The only marginal benefit is that joining ensures that records aren't returned in cases where a user has since been deleted from the `wp_users` table, but I'm guessing this is very much an edge case, since WP marks users as deleted rather than removing their rows from `wp_users`. As such, I think we can simply remove the `JOIN` clause.

As in #133, the presence of the JOIN is breaking the functionality altogether in cases where the user table is not kept in the same database as the site's H5P tables.