### PR TITLE
hook 'h5p_save_content' after inserting or updating content

### DIFF
--- a/public/class-h5p-wordpress.php
+++ b/public/class-h5p-wordpress.php
@@ -487,6 +487,8 @@ class H5PWordPress implements H5PFrameworkInterface {
         $content['library']['machineName'],
         $content['library']['majorVersion'] . '.' . $content['library']['minorVersion']);
 
+    do_action('h5p_save_content', $content['id'], $metadata);
+
     return $content['id'];
   }
 

--- a/public/class-h5p-wordpress.php
+++ b/public/class-h5p-wordpress.php
@@ -487,7 +487,12 @@ class H5PWordPress implements H5PFrameworkInterface {
         $content['library']['machineName'],
         $content['library']['majorVersion'] . '.' . $content['library']['minorVersion']);
 
-    do_action('h5p_save_content', $content['id'], $metadata);
+    do_action('h5p_save_content', $content['id'], $content);
+
+    $events = explode(' ', $event_type);
+    foreach ($events as $event) {
+      do_action("h5p_{$event}_content", $content['id'], $content);
+    }
 
     return $content['id'];
   }
@@ -531,6 +536,8 @@ class H5PWordPress implements H5PFrameworkInterface {
    */
   public function deleteContentData($id) {
     global $wpdb;
+
+    do_action('h5p_deleted_content', $id);
 
     // Remove content data and library usage
     $wpdb->delete($wpdb->prefix . 'h5p_contents', array('id' => $id), array('%d'));


### PR DESCRIPTION
The 'h5p_save_content' hook allows other system components to respond to the event of saving H5P content. This can be useful for performing additional tasks, such as notifying users, synchronizing data with other systems, or any other operation necessary after saving the content. It is also beneficial for developers as they can extend and customize the system's behavior without directly modifying the core code. This allows for different functionalities to be added or modified in a more modular and organized manner.