### PR TITLE
HFP-3943 Use user's profile language instead of site language

### DIFF
--- a/public/class-h5p-plugin.php
+++ b/public/class-h5p-plugin.php
@@ -806,9 +806,8 @@ class H5P_Plugin {
    * @return string
    */
   public function get_language() {
-    if (defined('WPLANG')) {
-      $language = WPLANG;
-    }
+    $user = wp_get_current_user();
+    $language = get_user_meta($user->ID, 'locale', true);
 
     if (empty($language)) {
       $language = get_option('WPLANG');


### PR DESCRIPTION
When merged in, will use the users' profile language for the H5P editor instead of using the site's language which can differ.

Note: The use of `WPLANG` is deprcated.