### PR TITLE
fix: FILTER_SANITIZE_STRING deprecation

### DIFF
--- a/admin/class-h5p-plugin-admin.php
+++ b/admin/class-h5p-plugin-admin.php
@@ -550,7 +550,8 @@ class H5P_Plugin_Admin {
    * @return string
    */
   public function alter_title($admin_title, $title) {
-    $page = filter_input(INPUT_GET, 'page', FILTER_SANITIZE_STRING);
+    $page = filter_input(INPUT_GET, 'page');
+    $page = htmlspecialchars($page ?? '', ENT_QUOTES, 'UTF-8');
 
     switch ($page) {
       case 'h5p':


### PR DESCRIPTION
### Problem

PHP Deprecated:  Constant FILTER_SANITIZE_STRING is deprecated in /class-h5p-plugin-admin.php on line 553

### Solution

Replace current deprecated code with a suitable option, keeping the current functionality intact

Address #152 #170 