### PR TITLE
Fixes to php depreciations and warnings

### DIFF
--- a/admin/class-h5p-content-admin.php
+++ b/admin/class-h5p-content-admin.php
@@ -64,7 +64,7 @@ class H5PContentAdmin {
    * @return string
    */
   public function alter_title($page, $admin_title, $title) {
-    $task = filter_input(INPUT_GET, 'task', FILTER_SANITIZE_STRING);
+    $task = filter_input(INPUT_GET, 'task', FILTER_UNSAFE_RAW);
     $id = filter_input(INPUT_GET, 'id', FILTER_SANITIZE_NUMBER_INT);
 
     // Find content title
@@ -176,7 +176,7 @@ class H5PContentAdmin {
    * @since 1.1.0
    */
   public function display_contents_page() {
-    switch (filter_input(INPUT_GET, 'task', FILTER_SANITIZE_STRING)) {
+    switch (filter_input(INPUT_GET, 'task', FILTER_UNSAFE_RAW)) {
       case NULL:
         include_once('views/contents.php');
 
@@ -872,7 +872,7 @@ class H5PContentAdmin {
   private function format_tags($tags) {
     // Tags come in CSV format, create Array instead
     $result = array();
-    $csvtags = explode(';', $tags);
+    $csvtags = !empty($tags)?explode(';', $tags):[];
     foreach ($csvtags as $csvtag) {
       if ($csvtag !== '') {
         $tag = explode(',', $csvtag);
@@ -1087,7 +1087,7 @@ class H5PContentAdmin {
     $editor = $this->get_h5peditor_instance();
 
     // Get input
-    $name = filter_input(INPUT_GET, 'machineName', FILTER_SANITIZE_STRING);
+    $name = filter_input(INPUT_GET, 'machineName', FILTER_UNSAFE_RAW);
     $major_version = filter_input(INPUT_GET, 'majorVersion', FILTER_SANITIZE_NUMBER_INT);
     $minor_version = filter_input(INPUT_GET, 'minorVersion', FILTER_SANITIZE_NUMBER_INT);
 
@@ -1117,7 +1117,7 @@ class H5PContentAdmin {
    * Get content type cache
    */
   public function ajax_content_type_cache() {
-    $token = filter_input(INPUT_GET, 'token', FILTER_SANITIZE_STRING);
+    $token = filter_input(INPUT_GET, 'token', FILTER_UNSAFE_RAW);
 
     $editor = $this->get_h5peditor_instance();
     $editor->ajax->action(H5PEditorEndpoints::CONTENT_TYPE_CACHE, $token);
@@ -1128,7 +1128,7 @@ class H5PContentAdmin {
    * Get translations
    */
   public function ajax_translations() {
-    $language = filter_input(INPUT_GET, 'language', FILTER_SANITIZE_STRING);
+    $language = filter_input(INPUT_GET, 'language', FILTER_UNSAFE_RAW);
 
     $editor = $this->get_h5peditor_instance();
     $editor->ajax->action(H5PEditorEndpoints::TRANSLATIONS, $language);
@@ -1141,7 +1141,7 @@ class H5PContentAdmin {
    * @since 1.1.0
    */
   public function ajax_files() {
-    $token = filter_input(INPUT_GET, 'token', FILTER_SANITIZE_STRING);
+    $token = filter_input(INPUT_GET, 'token', FILTER_UNSAFE_RAW);
     $contentId = filter_input(INPUT_POST, 'contentId', FILTER_SANITIZE_NUMBER_INT);
 
     $editor = $this->get_h5peditor_instance();
@@ -1176,7 +1176,7 @@ class H5PContentAdmin {
    * @since 1.14.0
    */
   public function ajax_filter() {
-    $token = filter_input(INPUT_GET, 'token', FILTER_SANITIZE_STRING);
+    $token = filter_input(INPUT_GET, 'token', FILTER_UNSAFE_RAW);
     $libraryParameters = filter_input(INPUT_POST, 'libraryParameters');
 
     $editor = $this->get_h5peditor_instance();

--- a/admin/class-h5p-content-query.php
+++ b/admin/class-h5p-content-query.php
@@ -395,9 +395,9 @@ class H5PContentQuery {
    *
    * @param array $results  Array of objects to limit.
    * @param int $offset  Offset to start at.
-   * @param int $limit  Number of items to return.
+   * @param int $limit  Number of items to return. Default 10
    */
-  protected function limit_results( $results = array(), $offset = 0, $limit ) {
+  protected function limit_results( $results = array(), $offset = 0, $limit = 10 ) {
     return array_slice( $results, $offset, $limit );
   }
 }

--- a/admin/class-h5p-editor-wordpress-storage.php
+++ b/admin/class-h5p-editor-wordpress-storage.php
@@ -110,7 +110,7 @@ class H5PEditorWordPressStorage implements H5peditorStorage {
           $library->title = $details->title;
           $library->runnable = $details->runnable;
           $library->restricted = $super_user ? FALSE : ($details->restricted === '1' ? TRUE : FALSE);
-          $library->metadataSettings = json_decode($details->metadata_settings);
+          $library->metadataSettings = $details->metadata_settings?json_decode($details->metadata_settings):[];
           $librariesWithDetails[] = $library;
         }
       }

--- a/admin/class-h5p-library-admin.php
+++ b/admin/class-h5p-library-admin.php
@@ -49,7 +49,7 @@ class H5PLibraryAdmin {
    * @return string
    */
   public function alter_title($page, $admin_title, $title) {
-    $task = filter_input(INPUT_GET, 'task', FILTER_SANITIZE_STRING);
+    $task = filter_input(INPUT_GET, 'task', FILTER_UNSAFE_RAW);
 
     // Find library title
     $show = ($task === 'show');
@@ -111,7 +111,7 @@ class H5PLibraryAdmin {
    * @since 1.1.0
    */
   public function display_libraries_page() {
-    switch (filter_input(INPUT_GET, 'task', FILTER_SANITIZE_STRING)) {
+    switch (filter_input(INPUT_GET, 'task', FILTER_UNSAFE_RAW)) {
       case NULL:
         $this->display_libraries();
         return;

--- a/admin/class-h5p-plugin-admin.php
+++ b/admin/class-h5p-plugin-admin.php
@@ -550,7 +550,7 @@ class H5P_Plugin_Admin {
    * @return string
    */
   public function alter_title($admin_title, $title) {
-    $page = filter_input(INPUT_GET, 'page', FILTER_SANITIZE_STRING);
+    $page = filter_input(INPUT_GET, 'page', FILTER_UNSAFE_RAW);
 
     switch ($page) {
       case 'h5p':

--- a/public/class-h5p-wordpress.php
+++ b/public/class-h5p-wordpress.php
@@ -19,6 +19,12 @@ class H5PWordPress implements H5PFrameworkInterface {
   private $networkSettings = array( 'content_type_cache_updated_at' );
 
   /**
+   *  Fix for php warning function
+   * 
+   */
+  public $plugin_slug;
+
+  /**
    * Implements setErrorMessage
    */
   public function setErrorMessage($message, $code = NULL) {


### PR DESCRIPTION
Fix for following warnings and notices

```
PHP Deprecated:  Constant FILTER_SANITIZE_STRING is deprecated in C:\xampp\htdocs\xxx\wp-content\plugins\h5p\admin\class-h5p-content-admin.php on line 179
PHP Deprecated:  Constant FILTER_SANITIZE_STRING is deprecated in C:\xampp\htdocs\xxx\wp-content\plugins\h5p\admin\class-h5p-library-admin.php on line 52
PHP Deprecated:  Creation of dynamic property H5PWordPress::$plugin_slug is deprecated in C:\xampp\htdocs\xxx\wp-content\plugins\h5p\public\class-h5p-wordpress.php on line 74
PHP Warning:  Undefined property: stdClass::$patch_version_in_folder_name in C:\xampp\htdocs\xxx\wp-content\plugins\h5p\h5p-editor-php-library\h5peditor.class.php on line 633
PHP Deprecated:  Optional parameter $results declared before required parameter $limit is implicitly treated as a required parameter in C:\xampp\htdocs\xxx\wp-content\plugins\h5p\admin\class-h5p-content-query.php on line 400
PHP Deprecated:  Optional parameter $offset declared before required parameter $limit is implicitly treated as a required parameter in C:\xampp\htdocs\xxx\wp-content\plugins\h5p\admin\class-h5p-content-query.php on line 400
PHP Deprecated:  json_decode(): Passing null to parameter #1 ($json) of type string is deprecated in C:\xampp\htdocs\xxx\wp-content\plugins\h5p\admin\class-h5p-editor-wordpress-storage.php on line 113
PHP Deprecated:  explode(): Passing null to parameter #2 ($string) of type string is deprecated in C:\xampp\htdocs\xxx\wp-content\plugins\h5p\admin\class-h5p-content-admin.php on line 875
```

Fix Reference: https://stackoverflow.com/questions/69207368/constant-filter-sanitize-string-is-deprecated