### PR TITLE
When filling user names, be sure to pull from entire network

### DIFF
--- a/admin/class-h5p-content-query.php
+++ b/admin/class-h5p-content-query.php
@@ -326,6 +326,7 @@ class H5PContentQuery {
      */
     $wp_users = get_users(
       array(
+        'blog_id' => null,
         'include' => array_unique( $user_ids ),
         'fields' => array('ID'),
       )

--- a/admin/class-h5p-plugin-admin.php
+++ b/admin/class-h5p-plugin-admin.php
@@ -973,6 +973,7 @@ class H5P_Plugin_Admin {
      */
     $wp_users = get_users(
       array(
+        'blog_id' => null,
         'include' => array_unique( $user_ids ),
         'fields' => array('ID'),
       )


### PR DESCRIPTION
When filling user names using `get_users()`, the default WP behavior is to pull users who have a role on the current site. If H5P is running on a specific site in a Multisite network, and if a logged-in user interacts with a piece of H5P content but that user does not have a role on the specific site where H5P is active, then the user's name will be left blank in the Dashboard 'Results' views. The proposed change tells WP to pull up the user corresponding to the provided `user_id`, regardless of whether that user has a role on the current site.