### PR TITLE
Add optional setting to use system temp directory for H5P temporary files

### DIFF
--- a/admin/class-h5p-plugin-admin.php
+++ b/admin/class-h5p-plugin-admin.php
@@ -495,6 +495,10 @@ class H5P_Plugin_Admin {
 
       $send_usage_statistics = filter_input(INPUT_POST, 'send_usage_statistics', FILTER_VALIDATE_BOOLEAN);
       update_option('h5p_send_usage_statistics', $send_usage_statistics);
+
+      $use_system_temp_dir = filter_input(INPUT_POST, 'use_system_temp_dir', FILTER_VALIDATE_BOOLEAN);
+      update_option('h5p_use_system_temp_dir', $use_system_temp_dir);
+
     }
     else {
       $frame = get_option('h5p_frame', TRUE);
@@ -511,6 +515,7 @@ class H5P_Plugin_Admin {
       $enable_hub = get_option('h5p_hub_is_enabled', TRUE);
 //      $site_key = get_option('h5p_site_key', get_option('h5p_h5p_site_uuid', FALSE));
       $send_usage_statistics = get_option('h5p_send_usage_statistics', TRUE);
+      $use_system_temp_dir = get_option('h5p_use_system_temp_dir', FALSE);
     }
 
     // Attach disable hub configuration

--- a/admin/views/settings.php
+++ b/admin/views/settings.php
@@ -211,6 +211,18 @@
             </p>
           </td>
         </tr>
+        <tr valign="top">
+          <th scope="row"><?php _e("Temporary Storage Location", $this->plugin_slug); ?></th>
+          <td>
+            <label>
+              <input name="use_system_temp_dir" type="checkbox" value="true"<?php if ($use_system_temp_dir): ?> checked="checked"<?php endif; ?>/>
+              <?php _e("Use system temporary folder", $this->plugin_slug); ?>
+            </label>
+            <p class="h5p-setting-desc">
+              <?php _e("When enabled, H5P will store temporary files (such as uploads during editing) in your server's system temporary folder instead of the plugin directory. This can improve performance on servers with limited resources.", $this->plugin_slug); ?>
+            </p>
+          </td>
+        </tr>
       </tbody>
     </table>
     <?php wp_nonce_field('h5p_settings', 'save_these_settings'); ?>

--- a/public/class-h5p-plugin.php
+++ b/public/class-h5p-plugin.php
@@ -396,6 +396,7 @@ class H5P_Plugin {
     add_option('h5p_hub_is_enabled', FALSE);
     add_option('h5p_send_usage_statistics', FALSE);
     add_option('h5p_has_request_user_consent', FALSE);
+    add_option('h5p_use_system_temp_dir', FALSE);
   }
 
   /**

--- a/public/class-h5p-plugin.php
+++ b/public/class-h5p-plugin.php
@@ -1735,6 +1735,7 @@ class H5P_Plugin {
     delete_option('h5p_check_h5p_requirements');
     delete_option('h5p_hub_is_enabled');
     delete_option('h5p_send_usage_statistics');
+    delete_option('h5p_use_system_temp_dir');
     delete_option('h5p_has_request_user_consent');
 
     // Clean out file dirs.

--- a/public/class-h5p-plugin.php
+++ b/public/class-h5p-plugin.php
@@ -1757,6 +1757,14 @@ class H5P_Plugin {
     if (is_dir($path) && count(scandir($path)) === 2) {
       rmdir($path);
     }
+
+    // Remove the staging dir in the system temp dir, but only if it's empty.
+    // It is shared by all sites in a network and may hold uploads in progress,
+    // and it is recreated on demand, so it must never be removed recursively.
+    $system_tmp = H5PWordPress::getSystemTmpParentPath();
+    if (is_dir($system_tmp) && count(scandir($system_tmp)) === 2) {
+      rmdir($system_tmp);
+    }
   }
 
   /**

--- a/public/class-h5p-wordpress.php
+++ b/public/class-h5p-wordpress.php
@@ -100,9 +100,13 @@ class H5PWordPress implements H5PFrameworkInterface {
     static $dir;
 
     if (is_null($dir)) {
-      $plugin = H5P_Plugin::get_instance();
-      $core = $plugin->get_h5p_instance('core');
-      $dir = $core->fs->getTmpPath();
+      if (get_option('h5p_use_system_temp_dir', FALSE)) {
+        $dir = sys_get_temp_dir();
+      } else {
+        $plugin = H5P_Plugin::get_instance();
+        $core = $plugin->get_h5p_instance('core');
+        $dir = $core->fs->getTmpPath();
+      }
     }
 
     return $dir;
@@ -115,9 +119,13 @@ class H5PWordPress implements H5PFrameworkInterface {
     static $path;
 
     if (is_null($path)) {
-      $plugin = H5P_Plugin::get_instance();
-      $core = $plugin->get_h5p_instance('core');
-      $path = $core->fs->getTmpPath() . '.h5p';
+      if (get_option('h5p_use_system_temp_dir', FALSE)) {
+        $path = sys_get_temp_dir() . '.h5p';
+      } else {
+        $plugin = H5P_Plugin::get_instance();
+        $core = $plugin->get_h5p_instance('core');
+        $path = $core->fs->getTmpPath() . '.h5p';
+      }
     }
 
     return $path;

--- a/public/class-h5p-wordpress.php
+++ b/public/class-h5p-wordpress.php
@@ -95,6 +95,18 @@ class H5PWordPress implements H5PFrameworkInterface {
   }
 
   /**
+   * Get path to the folder H5P stages uploads in inside the system temp
+   * directory. Derived from the WordPress installation path, so installations
+   * sharing a server do not share a staging folder. Note that all sites in a
+   * network do share it.
+   *
+   * @return string
+   */
+  public static function getSystemTmpParentPath() {
+    return rtrim(sys_get_temp_dir(), '/\\') . '/h5p-' . substr(md5(ABSPATH), 0, 8);
+  }
+
+  /**
    * Get path to a new unique tmp folder inside the system temp directory.
    *
    * Staging happens in a dedicated, non-listable subfolder rather than
@@ -106,7 +118,7 @@ class H5PWordPress implements H5PFrameworkInterface {
    *  can not be used (missing, not writable or outside open_basedir).
    */
   private function getSystemTmpPath() {
-    $parent = rtrim(sys_get_temp_dir(), '/\\') . '/h5p-' . substr(md5(ABSPATH), 0, 8);
+    $parent = self::getSystemTmpParentPath();
 
     // Suppress warnings, an unusable temp dir is handled by the return value.
     if (!@wp_mkdir_p($parent) || !@is_writable($parent)) {
@@ -114,7 +126,9 @@ class H5PWordPress implements H5PFrameworkInterface {
     }
     @chmod($parent, 0700);
 
-    return $parent . '/' . uniqid('h5p-');
+    // Using wp_generate_password() to generate string to use as part of the
+    // parent directory name
+    return $parent . '/h5p-' . wp_generate_password(16, FALSE);
   }
 
   /**

--- a/public/class-h5p-wordpress.php
+++ b/public/class-h5p-wordpress.php
@@ -95,6 +95,38 @@ class H5PWordPress implements H5PFrameworkInterface {
   }
 
   /**
+   * Get path to a new unique tmp folder inside the system temp directory.
+   *
+   * Staging happens in a dedicated, non-listable subfolder rather than
+   * directly in the system temp directory, so other local users can not
+   * predict and pre-create the paths we are about to write to.
+   *
+   * @return string|bool
+   *  Unique path without extension, or FALSE if the system temp directory
+   *  can not be used (missing, not writable or outside open_basedir).
+   */
+  private function getSystemTmpPath() {
+    $parent = rtrim(sys_get_temp_dir(), '/\\') . '/h5p-' . substr(md5(ABSPATH), 0, 8);
+
+    // Suppress warnings, an unusable temp dir is handled by the return value.
+    if (!@wp_mkdir_p($parent) || !@is_writable($parent)) {
+      return FALSE;
+    }
+    @chmod($parent, 0700);
+
+    return $parent . '/' . uniqid('h5p-');
+  }
+
+  /**
+   * Helper, get path to the H5P tmp folder in the plugin directory.
+   */
+  private function getPluginTmpPath() {
+    $plugin = H5P_Plugin::get_instance();
+    $core = $plugin->get_h5p_instance('core');
+    return $core->fs->getTmpPath();
+  }
+
+  /**
    * Implements getUploadedH5PFolderPath
    */
   public function getUploadedH5pFolderPath() {
@@ -102,11 +134,12 @@ class H5PWordPress implements H5PFrameworkInterface {
 
     if (is_null($dir)) {
       if (get_option('h5p_use_system_temp_dir', FALSE)) {
-        $dir = sys_get_temp_dir();
-      } else {
-        $plugin = H5P_Plugin::get_instance();
-        $core = $plugin->get_h5p_instance('core');
-        $dir = $core->fs->getTmpPath();
+        $dir = $this->getSystemTmpPath();
+      }
+
+      if (empty($dir)) {
+        // Not using or unable to use the system temp dir, fall back.
+        $dir = $this->getPluginTmpPath();
       }
     }
 
@@ -121,12 +154,15 @@ class H5PWordPress implements H5PFrameworkInterface {
 
     if (is_null($path)) {
       if (get_option('h5p_use_system_temp_dir', FALSE)) {
-        $path = sys_get_temp_dir() . '.h5p';
-      } else {
-        $plugin = H5P_Plugin::get_instance();
-        $core = $plugin->get_h5p_instance('core');
-        $path = $core->fs->getTmpPath() . '.h5p';
+        $path = $this->getSystemTmpPath();
       }
+
+      if (empty($path)) {
+        // Not using or unable to use the system temp dir, fall back.
+        $path = $this->getPluginTmpPath();
+      }
+
+      $path .= '.h5p';
     }
 
     return $path;


### PR DESCRIPTION
Hello,

This pull request introduces an optional admin setting that allows H5P to store temporary/working files in the server’s system temporary directory (via PHP's [sys_get_temp_dir()](https://www.php.net/manual/en/function.sys-get-temp-dir.php) function) instead of the H5P plugin directory.

**Background**

In our environment, WordPress content is stored on AWS Elastic File System (EFS). While EFS works well for persistent content, it performs poorly when handling large numbers of small, frequently changing files—such as those created during H5P uploads and processing.

By using the server's system temp directory for these temporary files, we've observed:

- Significantly faster upload and processing times
- Reduced I/O overhead on networked file systems like EFS
- Improved performance on resource-constrained servers

This aligns with common best practices of using local system temp storage for short-lived working files.

**What This PR Does**

- Adds a new admin-configurable setting to enable use of the system temp directory for H5P temporary files
- Keeps the setting disabled by default, preserving existing behavior
- Ensures the change is **fully opt-in** and does **not impact existing installations** unless explicitly enabled by an administrator

**Backward Compatibility & Safety**

- No changes to default behavior
- No migration required
- Existing installs will continue to use the current plugin directory unless the setting is enabled
- The feature is isolated to temporary file handling only

This pull request is based on the earlier work from PR #130, originally submitted several years ago. That PR was created by my colleague and did not receive any follow-up, so this submission reintroduces the feature with minor updates to align with the current H5P codebase.

Thank you for considering this improvement. I'm happy to adjust the implementation or documentation if needed.