### PR TITLE
Fix: Add missing resetHubOrganizationData interface method

### DIFF
--- a/public/class-h5p-wordpress.php
+++ b/public/class-h5p-wordpress.php
@@ -1310,4 +1310,5 @@ class H5PWordPress implements H5PFrameworkInterface {
   public function getContentHubMetadataCache($lang = 'en') { die('Called'); return json_encode([]); }
   public function getContentHubMetadataChecked($lang = 'en') {return []; }
   public function setContentHubMetadataChecked($time, $lang = 'en') { return []; }
+  public function resetHubOrganizationData() {}
 }


### PR DESCRIPTION
This method is part of the interface and it's conflicting with the new 1.28.0 core

> PHP Fatal error:  Class H5PWordPress contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (H5PFrameworkInterface::resetHubOrganizationData)