### PR TITLE
fix: remove redundant wpdb::prepare() on placeholder-free H5P query

### DIFF
--- a/public/class-h5p-plugin.php
+++ b/public/class-h5p-plugin.php
@@ -517,7 +517,7 @@ class H5P_Plugin {
                  ($v->major === 1 && $v->minor === 17 && $v->patch < 6)); // < 1.17.5
     if ($pre_1176) {
       // Clear filteredParameters
-      $wpdb->query($wpdb->prepare("UPDATE {$wpdb->prefix}h5p_contents SET filtered = ''"));
+      $wpdb->query("UPDATE {$wpdb->prefix}h5p_contents SET filtered = ''");
     }
 
     // Keep track of which version of the plugin we have.


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix

**What is the current behaviour?**
With `WP_DEBUG` enabled, activating/upgrading the plugin triggers a `wpdb::prepare()` "must have a placeholder" notice, because the placeholder-free query in `check_for_updates()` is needlessly wrapped in `$wpdb->prepare()`.

**What is the new behaviour?**
The query runs directly via `$wpdb->query()` (no `prepare()`), so it executes exactly as before but without the notice.
