### PR TITLE
Ensure loadAddons returns an array

### DIFF
--- a/public/class-h5p-wordpress.php
+++ b/public/class-h5p-wordpress.php
@@ -1276,7 +1276,7 @@ class H5PWordPress implements H5PFrameworkInterface {
               (l1.major_version = l2.major_version AND
                l1.minor_version < l2.minor_version))
         WHERE l1.add_to IS NOT NULL AND l2.name IS NULL", ARRAY_A
-    );
+    ) ?? [];
 
     // NOTE: These are treated as library objects but are missing the following properties:
     // title, embed_types, drop_library_css, fullscreen, runnable, semantics, has_icon


### PR DESCRIPTION
Thank you for your interest in contributing to H5P! 🎉  
Please fill in the below sections to make your pull request:

**What kind of change does this PR introduce?**
Bug fix

**What is the current behaviour?**
The H5P framework interface requires the `loadAddon` function to return an array (https://github.com/h5p/h5p-php-library/blob/cb64a1f3884408487c3178e31fc140f5d45ca165/h5p.classes.php#L110-L114). However, the current implementation will return `null` if the SQL query fails (https://github.com/h5p/h5p-wordpress-plugin/blob/2a606652d66deaeb02c1c71bde9a7d2bd45839b5/public/class-h5p-wordpress.php#L861-L873).

**What is the new behaviour?**
If the SQL query fails, an empty array will be returned (silently failing) to honor the interface.

## PR Checklist

Before submitting, please confirm:

- [x] I searched for existing issues/PRs first
- [x] I linked related issues/discussions
- [x] I tested my changes locally

Read the [contribution guidelines](https://github.com/h5p/.github/blob/master/CONTRIBUTING.md) to get your pr accepted more quickly.
